### PR TITLE
Bonus bugfix: Fixed TokenService thowing exceptions by wrapping tokenHandler.ValidateToken() in try-catch.

### DIFF
--- a/src/MCC.TestTask/MCC.TestTask.App/Services/Auth/TokenService.cs
+++ b/src/MCC.TestTask/MCC.TestTask.App/Services/Auth/TokenService.cs
@@ -139,13 +139,21 @@ public class TokenService
         };
 
         var tokenHandler = new JwtSecurityTokenHandler();
-        var principal = tokenHandler.ValidateToken(token, tokenValidationParameters, out var securityToken);
-
-        if (!(securityToken is JwtSecurityToken jwtSecurityToken) ||
-            !jwtSecurityToken.Header.Alg.Equals(SecurityAlgorithms.HmacSha256,
-                StringComparison.InvariantCultureIgnoreCase))
-            return Result.Fail(new ValidationError("Invalid token"));
-
-        return principal;
+        
+        try
+        {
+            var principal = tokenHandler.ValidateToken(token, tokenValidationParameters, out var securityToken);
+            
+            if (!(securityToken is JwtSecurityToken jwtSecurityToken) ||
+                !jwtSecurityToken.Header.Alg.Equals(SecurityAlgorithms.HmacSha256,
+                    StringComparison.InvariantCultureIgnoreCase))
+                return Result.Fail(new ValidationError("Invalid token"));
+            
+            return principal;
+        }
+        catch (ArgumentException argumentException)
+        {
+            return Result.Fail(new ValidationError("Invalid token structure"));
+        }
     }
 }


### PR DESCRIPTION
It was happening every time the client didn't put "Bearer" before the actual token.
Now frontenders won't be gasping after sending the token with wrong structure ;)